### PR TITLE
Improve schema overrides and flag parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ claude mcp add --scope project cursor-reviewer $(pwd)/bin/cursor-reviewer-mcp
 ## 環境変数
 - 通常は不要です。`cursor-agent` や `codex` が既にローカル設定済みであれば、環境変数は不要です。
 - 特殊な環境（CI 等）で `cursor-agent` が環境変数経由の認証を要求する場合のみ、`CURSOR_API_KEY` を設定してください。
-- Codex CLI のパスを明示する場合は `REVIEWER_MCP_CODEX_BIN`、追加フラグは `REVIEWER_MCP_CODEX_FLAGS` を設定します（空白で区切り、例: `--model gpt-4 --quiet`）。
+- Codex CLI のパスを明示する場合は `REVIEWER_MCP_CODEX_BIN`、追加フラグは `REVIEWER_MCP_CODEX_FLAGS` を設定します（シェル風の記法で引用可、例: `--model "gpt 4" --quiet`）。
+- スキーマを差し替える場合は `REVIEWER_MCP_SCHEMA_DIR`（ディレクトリを指定）、または個別に `REVIEWER_MCP_CURSOR_SCHEMA_PATH` / `REVIEWER_MCP_CODEX_SCHEMA_PATH` を指定します。
 - JSON以外の出力を許容する場合のみ `REVIEWER_MCP_ALLOW_PLAINTEXT_FALLBACK=1` を設定します（デフォルトは厳格にJSONのみ）。
 
 ## ツール仕様（要点）

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "build": "tsc -p tsconfig.json && node scripts/copy-assets.mjs",
     "start": "node dist/server.js",
     "dev": "tsx src/server.ts",
-    "typecheck": "tsc -p tsconfig.json --noEmit"
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "node --test --import tsx"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "latest"

--- a/src/codex.ts
+++ b/src/codex.ts
@@ -5,6 +5,7 @@ import {
   persistReview,
   type ReviewInput
 } from './review.js';
+import { parseFlags } from './flags.js';
 
 export async function runCodexReview(input: ReviewInput): Promise<any> {
   const prompt = buildPrompt(input);
@@ -22,7 +23,7 @@ async function callCodexAndParse(prompt: string, timeoutMs: number): Promise<any
   const allowPlainFallback = process.env.REVIEWER_MCP_ALLOW_PLAINTEXT_FALLBACK === '1' ||
     process.env.REVIEWER_MCP_ALLOW_PLAINTEXT_FALLBACK === 'true';
   const bin = process.env.REVIEWER_MCP_CODEX_BIN || 'codex';
-  const flags = (process.env.REVIEWER_MCP_CODEX_FLAGS || '').split(/\s+/).filter(Boolean);
+  const flags = parseFlags(process.env.REVIEWER_MCP_CODEX_FLAGS || '');
   const args = ['exec', ...flags, prompt];
 
   let stdout: string;

--- a/src/cursor.ts
+++ b/src/cursor.ts
@@ -22,11 +22,19 @@ async function callCursorAndParse(prompt: string, timeoutMs: number): Promise<an
   const allowPlainFallback =
     process.env.REVIEWER_MCP_ALLOW_PLAINTEXT_FALLBACK === '1' ||
     process.env.REVIEWER_MCP_ALLOW_PLAINTEXT_FALLBACK === 'true';
-  const { stdout } = await execWithTimeout(
-    'cursor-agent',
-    ['-p', '-f', '--model', 'gpt-5', '--output-format', 'json', prompt],
-    timeoutMs
-  );
+  let stdout: string;
+  try {
+    ({ stdout } = await execWithTimeout(
+      'cursor-agent',
+      ['-p', '--model', 'gpt-5', '--output-format', 'json', prompt],
+      timeoutMs
+    ));
+  } catch (e: any) {
+    if (e && (e.code === 'ENOENT' || /ENOENT/.test(e.message))) {
+      throw new Error("Cursor CLI not found: install 'cursor-agent'.");
+    }
+    throw e;
+  }
 
   // First parse: Cursor CLI JSON
   let top: any;

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -1,0 +1,52 @@
+export function parseFlags(input: string): string[] {
+  const result: string[] = [];
+  let cur = '';
+  let inSingle = false;
+  let inDouble = false;
+  let esc = false;
+  for (const ch of input) {
+    if (esc) {
+      cur += ch;
+      esc = false;
+      continue;
+    }
+    if (ch === '\\') {
+      esc = true;
+      continue;
+    }
+    if (inSingle) {
+      if (ch === "'") {
+        inSingle = false;
+      } else {
+        cur += ch;
+      }
+      continue;
+    }
+    if (inDouble) {
+      if (ch === '"') {
+        inDouble = false;
+      } else {
+        cur += ch;
+      }
+      continue;
+    }
+    if (ch === "'") {
+      inSingle = true;
+      continue;
+    }
+    if (ch === '"') {
+      inDouble = true;
+      continue;
+    }
+    if (/\s/.test(ch)) {
+      if (cur) {
+        result.push(cur);
+        cur = '';
+      }
+      continue;
+    }
+    cur += ch;
+  }
+  if (cur) result.push(cur);
+  return result;
+}

--- a/src/review.ts
+++ b/src/review.ts
@@ -1,4 +1,4 @@
-import { readFileSync, writeFileSync } from 'node:fs';
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
 import { spawn } from 'node:child_process';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -14,6 +14,12 @@ export type ReviewInput = {
   timeout_ms?: number;
   policy?: string | null;
 };
+
+export function normalizeReviewInput(input: { reference?: Reference[] }): void {
+  if (!Array.isArray(input.reference)) {
+    input.reference = [];
+  }
+}
 
 export function buildPrompt(input: ReviewInput): string {
   const tmplPathOverride = process.env.REVIEWER_MCP_TEMPLATE_PATH;
@@ -79,7 +85,6 @@ function looksLikeJson(s: string): boolean {
 function extractBalancedFrom(src: string, start: number): string | null {
   const open = src[start];
   if (open !== '{' && open !== '[') return null;
-  const closing = open === '{' ? '}' : ']';
   let depth = 0;
   let inStr = false;
   let esc = false;
@@ -135,7 +140,9 @@ export function persistReview(obj: any) {
     const ts = new Date();
     const pad = (n: number) => n.toString().padStart(2, '0');
     const name = `${ts.getFullYear()}${pad(ts.getMonth() + 1)}${pad(ts.getDate())}-${pad(ts.getHours())}${pad(ts.getMinutes())}${pad(ts.getSeconds())}.json`;
-    const path = join(process.cwd(), 'reviews', name);
+    const dir = join(process.cwd(), 'reviews');
+    mkdirSync(dir, { recursive: true });
+    const path = join(dir, name);
     writeFileSync(path, JSON.stringify(obj, null, 2), 'utf8');
   } catch {
     // best-effort; ignore persistence errors

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { runCursorReview } from './cursor.js';
 import { runCodexReview } from './codex.js';
-import type { ReviewInput } from './review.js';
+import { normalizeReviewInput, type ReviewInput } from './review.js';
 
 // MCP SDK
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
@@ -16,11 +16,20 @@ import {
 } from '@modelcontextprotocol/sdk/types.js';
 
 // Resolve schema JSON relative to this file, allowing env override
-const schemaPathOverride = process.env.REVIEWER_MCP_SCHEMA_PATH;
-const cursorSchemaPath = schemaPathOverride
-  ? schemaPathOverride
+const schemaDirOverride = process.env.REVIEWER_MCP_SCHEMA_DIR;
+const cursorSchemaPathOverride =
+  process.env.REVIEWER_MCP_CURSOR_SCHEMA_PATH || process.env.REVIEWER_MCP_SCHEMA_PATH;
+const codexSchemaPathOverride = process.env.REVIEWER_MCP_CODEX_SCHEMA_PATH;
+const cursorSchemaPath = cursorSchemaPathOverride
+  ? cursorSchemaPathOverride
+  : schemaDirOverride
+  ? path.join(schemaDirOverride, 'cursor.review.input.schema.json')
   : fileURLToPath(new URL('./schemas/cursor.review.input.schema.json', import.meta.url));
-const codexSchemaPath = fileURLToPath(new URL('./schemas/codex.review.input.schema.json', import.meta.url));
+const codexSchemaPath = codexSchemaPathOverride
+  ? codexSchemaPathOverride
+  : schemaDirOverride
+  ? path.join(schemaDirOverride, 'codex.review.input.schema.json')
+  : fileURLToPath(new URL('./schemas/codex.review.input.schema.json', import.meta.url));
 const cursorInputSchema = JSON.parse(readFileSync(cursorSchemaPath, 'utf8'));
 const codexInputSchema = JSON.parse(readFileSync(codexSchemaPath, 'utf8'));
 
@@ -80,6 +89,7 @@ async function main() {
     if (!input || !Array.isArray(input.targets) || typeof input.review_request !== 'string') {
       throw new Error('Invalid input: missing required fields');
     }
+    normalizeReviewInput(input);
     validateTargets(input.targets);
     validateRefs('reference', input.reference);
     validateRefs('previous_reviews', input.previous_reviews);

--- a/test/buildPrompt.test.ts
+++ b/test/buildPrompt.test.ts
@@ -1,0 +1,25 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { buildPrompt } from '../src/review.js';
+
+describe('buildPrompt', () => {
+  it('replaces placeholders', () => {
+    const tmpl = 'Req: {{review_request}}\nTargets: {{targets_json}}\nRef: {{reference_json}}\nPrev: {{previous_reviews_json}}\nFollow: {{follow_up_instructions}}';
+    const file = join(tmpdir(), 'tmpl.txt');
+    writeFileSync(file, tmpl, 'utf8');
+    const envBackup = process.env.REVIEWER_MCP_TEMPLATE_PATH;
+    process.env.REVIEWER_MCP_TEMPLATE_PATH = file;
+    const prompt = buildPrompt({
+      targets: [{ file: 'f', path: 'p' }],
+      reference: [],
+      review_request: 'rr'
+    } as any);
+    process.env.REVIEWER_MCP_TEMPLATE_PATH = envBackup;
+    assert(prompt.includes('Req: rr'));
+    assert(prompt.includes('Targets: [\n  {\n    "file": "f",\n    "path": "p"\n  }\n]'));
+    assert(prompt.includes('Ref: []'));
+  });
+});

--- a/test/extractJsonString.test.ts
+++ b/test/extractJsonString.test.ts
@@ -1,0 +1,10 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { extractJsonString } from '../src/review.js';
+
+describe('extractJsonString', () => {
+  it('extracts json within fences', () => {
+    const text = '```json\n{"a":1}\n```';
+    assert.equal(extractJsonString(text), '{"a":1}');
+  });
+});

--- a/test/flags.test.ts
+++ b/test/flags.test.ts
@@ -1,0 +1,14 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseFlags } from '../src/flags.js';
+
+describe('parseFlags', () => {
+  it('handles quotes with spaces', () => {
+    const res = parseFlags('--model "gpt 4" --quiet');
+    assert.deepEqual(res, ['--model', 'gpt 4', '--quiet']);
+  });
+  it('handles single quotes', () => {
+    const res = parseFlags("--opt 'hello world'");
+    assert.deepEqual(res, ['--opt', 'hello world']);
+  });
+});

--- a/test/reference.test.ts
+++ b/test/reference.test.ts
@@ -1,0 +1,11 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { normalizeReviewInput } from '../src/review.js';
+
+describe('normalizeReviewInput', () => {
+  it('defaults reference to []', () => {
+    const input: any = { targets: [], review_request: 'r' };
+    normalizeReviewInput(input);
+    assert.deepEqual(input.reference, []);
+  });
+});


### PR DESCRIPTION
## Summary
- handle missing `cursor-agent` gracefully and drop unused `-f` flag
- add reference normalization, schema overrides, and review persistence directory creation
- parse `REVIEWER_MCP_CODEX_FLAGS` with shell-style quoting and document new env vars

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b30913e554832d8bc01aac9ec0c0a7